### PR TITLE
fix a CALLPTR bug

### DIFF
--- a/nox_lang.rb
+++ b/nox_lang.rb
@@ -413,7 +413,7 @@ module NoxLang
           return
         when 0x1D
           # CALLPTR
-          addr = (ip - 256) / 3
+          addr = ((ip - 256) / 3 + 2) & 0xFF
           memory[p0] = addr
         else
           puts ERROR_OPC_RANGE


### PR DESCRIPTION
The return address would be invalid. Fixed by adding 2 and ANDing with 0xFF.